### PR TITLE
add Atomist webhook to Travis

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -1,0 +1,16 @@
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170816122823"
+editor:
+  name: "AddTravisWebhookEditor"
+  group: "atomist"
+  artifact: "enrollment-rugs"
+  version: "0.3.40"
+  origin:
+    repo: "git@github.com:atomisthq/enrollment-rugs"
+    branch: "master"
+    sha: "2df11e5"
+  parameters:
+    - "atomistWebhookUrl": "https://webhook-staging.atomist.services/atomist/travis"
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.atomist.yml linguist-generated=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,10 @@
 script: echo whee
+notifications:
+  webhooks:
+    urls:
+    - 'https://webhook-staging.atomist.services/travis'
+    on_cancel: always
+    on_error: always
+    on_start: always
+    on_failure: always
+    on_success: always


### PR DESCRIPTION
Created by Atomist Editor `AddTravisWebhookEditor`
```
---
kind: "operation"
client: "com.atomist:rug"
version: "1.0.0-20170816122823"
editor:
  name: "AddTravisWebhookEditor"
  group: "atomist"
  artifact: "enrollment-rugs"
  version: "0.3.40"
  origin:
    repo: "git@github.com:atomisthq/enrollment-rugs"
    branch: "master"
    sha: "2df11e5"
  parameters:
    - "atomistWebhookUrl": "https://webhook-staging.atomist.services/atomist/travis"

```