### PR TITLE
Receive build notifications via Atomist

### DIFF
--- a/.atomist.yml
+++ b/.atomist.yml
@@ -1,0 +1,16 @@
+---
+kind: "operation"
+client: "com.atomist:rug"
+version: "1.0.0-20170816122823"
+editor:
+  name: "AddTravisWebhookEditor"
+  group: "atomist"
+  artifact: "enrollment-rugs"
+  version: "0.3.48"
+  origin:
+    repo: "git@github.com:atomisthq/enrollment-rugs.git"
+    branch: "master"
+    sha: "a5f3426"
+  parameters:
+    - "atomistWebhookUrl": "https://webhook-staging.atomist.services/atomist/travis"
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.atomist.yml linguist-generated=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,10 @@
 script: echo whee
+notifications:
+  webhooks:
+    urls:
+    - 'https://webhook-staging.atomist.services/travis'
+    on_cancel: always
+    on_error: always
+    on_start: always
+    on_failure: always
+    on_success: always


### PR DESCRIPTION
Send build events to Atomist.

They'll be incorporated into GitHub push and PR notifications,
so you'll see dynamically updated build results along with your commits.
Look for them in #xiaoping in Slack.

[Travis webhook documentation](https://docs.travis-ci.com/user/notifications/#Configuring-webhook-notifications)